### PR TITLE
passive assets

### DIFF
--- a/samples/Aeolus/pythonScripts/adcs.py
+++ b/samples/Aeolus/pythonScripts/adcs.py
@@ -42,6 +42,11 @@ class adcs(HSFSystem.Subsystem):
         return instance
 
     def CanPerform(self, event, universe):
+        # shorcut check for empty target
+        tgtName = event.GetAssetTask(self.Asset).Target.Name.ToString()
+        if (tgtName == 'EmptyTarget'):
+            return True
+
         timetoslew = 10
         es = event.GetEventStart(self.Asset)
         ts = event.GetTaskStart(self.Asset)

--- a/samples/Aeolus/pythonScripts/comm.py
+++ b/samples/Aeolus/pythonScripts/comm.py
@@ -42,6 +42,12 @@ class comm(HSFSystem.Subsystem):
     def CanPerform(self, event, universe):
         #print("Entry of Comm CanPreform")
         #print(self._task.Type)
+
+        # shorcut check for empty target
+        tgtName = event.GetAssetTask(self.Asset).Target.Name.ToString()
+        if (tgtName == 'EmptyTarget'):
+            return True
+
         if self._task.Type == "comm":
             newProf = self.DependencyCollector(event)
             if (newProf.Empty() == False):

--- a/samples/Aeolus/pythonScripts/eosensor.py
+++ b/samples/Aeolus/pythonScripts/eosensor.py
@@ -62,7 +62,12 @@ class eosensor(HSFSystem.Subsystem):
         return instance
 
     def CanPerform(self, event, universe):
-         if (self._task.Type == "imaging"):
+        # shorcut check for empty target
+        tgtName = event.GetAssetTask(self.Asset).Target.Name.ToString()
+        if (tgtName == 'EmptyTarget'):
+            return True
+
+        if (self._task.Type == "imaging"):
              value = self._task.Target.Value
              pixels = self._lowQualityPixels
              timetocapture = self._lowQualityTime

--- a/samples/Aeolus/pythonScripts/power.py
+++ b/samples/Aeolus/pythonScripts/power.py
@@ -43,7 +43,7 @@ class power(HSFSystem.Subsystem):
         instance._fullSolarPanelPower = 150
         instance._penumbraSolarPanelPower = 75
 
-        # values read from the xml file		
+        # values read from the xml file
         if (node.Attributes['batterySize'] != None):
             instance._batterySize = float(node.Attributes['batterySize'].Value)
         if (node.Attributes['fullSolarPower'] != None):
@@ -55,6 +55,11 @@ class power(HSFSystem.Subsystem):
 
     def CanPerform(self, event, universe):
         #print("Entry of Power CanPreform")
+        # shorcut check for empty target
+        tgtName = event.GetAssetTask(self.Asset).Target.Name.ToString()
+        if (tgtName == 'EmptyTarget'):
+            return True
+
         es = event.GetEventStart(self.Asset)
         te = event.GetTaskEnd(self.Asset)
         ee = event.GetEventEnd(self.Asset)

--- a/samples/Aeolus/pythonScripts/ssdr.py
+++ b/samples/Aeolus/pythonScripts/ssdr.py
@@ -40,6 +40,11 @@ class ssdr(HSFSystem.Subsystem):
         return instance
 
     def CanPerform(self, event, universe):
+        # shorcut check for empty target
+        tgtName = event.GetAssetTask(self.Asset).Target.Name.ToString()
+        if (tgtName == 'EmptyTarget'):
+            return True
+
         #print(self._task.Type)
         if (self._task.Type == "imaging"):
             ts = event.GetTaskStart(self.Asset)

--- a/src/HSFScheduler/Checker.cs
+++ b/src/HSFScheduler/Checker.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
-// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
+// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu) Scott Plantenga (splantenga@hotmail.com)
 
 using System;
 using System.Collections.Generic;
 using HSFSystem;
 using HSFUniverse;
-//using Logging;
+using MissionElements;
 
 namespace HSFScheduler
 {
@@ -19,6 +19,15 @@ namespace HSFScheduler
         /// <returns></returns>
         public static bool CheckSchedule(SystemClass system, SystemSchedule proposedSchedule)
         {
+            // First check that any Assets with IsTaskable = false is only tasked to EmptyTarget
+            foreach (KeyValuePair<Asset, Task> taskDict in proposedSchedule.AllStates.Events.Peek().Tasks)
+            {
+                if ((!taskDict.Key.IsTaskable) && (taskDict.Value.Type != "empty"))
+                {
+                    return false;
+                }
+            }
+
             // Iterate through Subsystem Nodes and set that they havent run
             foreach (var subsystem in system.Subsystems)
                 subsystem.IsEvaluated = false;
@@ -56,7 +65,7 @@ namespace HSFScheduler
                 return true;
 
             var events = proposedSchedule.AllStates.Events;
-            
+
             //if (events.Count != 0)
             //{
                 //if (events.Count > 1)

--- a/src/HSFScheduler/Scheduler.cs
+++ b/src/HSFScheduler/Scheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
 // Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
 
 using System;
@@ -158,15 +158,12 @@ namespace HSFScheduler
                             potentialSystemSchedules.Add(new SystemSchedule(CopySchedule, newAccessStack, currentTime));
                             // oldSched = new SystemSchedule(CopySchedule);
                         }
-
                     }
                 }
 
                 int numSched = 0;
                 foreach (var potentialSchedule in potentialSystemSchedules)
                 {
-
-
                     if (Checker.CheckSchedule(system, potentialSchedule)) {
                         systemCanPerformList.Add(potentialSchedule);
                         numSched++;
@@ -183,8 +180,8 @@ namespace HSFScheduler
                 potentialSystemSchedules.Clear();
                 systemCanPerformList.Clear();
 
-                // Print completion percentage in command window
-                Console.WriteLine("Scheduler Status: {0:F}% done; {1} schedules generated.", 100 * currentTime / _endTime, systemSchedules.Count);
+                // Print completion percentage and number of generated schedules in command window
+                Console.WriteLine("Scheduler Status: {0:F}% done; {1} schedules generated.", 100 * (currentTime + _stepLength) / _endTime, systemSchedules.Count);
             }
             return systemSchedules;
         }

--- a/src/Horizon/Program.cs
+++ b/src/Horizon/Program.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
-// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
+// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu) Scott Plantenga (splantenga@hotmail.com)
 
 using System;
 using System.Collections.Generic;
@@ -40,8 +40,8 @@ namespace Horizon
 
         public List<KeyValuePair<string, string>> DependencyList { get; set; } = new List<KeyValuePair<string, string>>();
         public List<KeyValuePair<string, string>> DependencyFcnList { get; set; } = new List<KeyValuePair<string, string>>();
-        
-        // Create Constraint list 
+
+        // Create Constraint list
         public List<Constraint> ConstraintsList { get; set; } = new List<Constraint>();
 
         //Create Lists to hold all the dependency nodes to be parsed later
@@ -113,7 +113,7 @@ namespace Horizon
             ModelInputFilePath = @"..\..\..\..\samples\Aeolus\DSAC_Static_Mod_Scripted.xml"; // Asset 1 Scripted, Asset 2 C#
             //ModelInputFilePath = @"..\..\..\..\samples\Aeolus\DSAC_Static_Mod_PartialScripted.xml"; // Asset 1 mix Scripted/C#, Asset 2 C#
             //ModelInputFilePath = @"..\..\..\..\samples\Aeolus\DSAC_Static_Mod.xml"; // Asset 1 C#, Asset 2 C#
-            
+
             bool simulationSet = false, targetSet = false, modelSet = false;
 
             // Get the input filenames
@@ -212,7 +212,7 @@ namespace Horizon
                 Console.WriteLine("Default Space Environment Loaded");
                 log.Info("Default Space Environment Loaded");
             }
-            
+
             // Load Environments
             foreach (XmlNode environmentNode in environments)
             {
@@ -230,7 +230,10 @@ namespace Horizon
             foreach(XmlNode assetNode in assets)
             {
                 Asset asset = new Asset(assetNode);
-                asset.AssetDynamicState.Eoms.SetEnvironment(SystemUniverse);
+                if (asset.AssetDynamicState.Eoms != null)
+                {
+                    asset.AssetDynamicState.Eoms.SetEnvironment(SystemUniverse);
+                }
                 AssetList.Add(asset);
 
                 // Load Subsystems
@@ -248,7 +251,7 @@ namespace Horizon
                     {
                         // Parse state node for key name and state type, add the key to the subsys's list of keys, return the key name
                         string keyName = SubsystemFactory.SetStateKeys(StateNode, subsys);
-                        // Use key name and state type to set initial conditions 
+                        // Use key name and state type to set initial conditions
                         InitialSysState.SetInitialSystemState(StateNode, keyName);
                     }
                 }
@@ -310,7 +313,7 @@ namespace Horizon
             {
                 systemSchedule.ScheduleValue = SchedEvaluator.Evaluate(systemSchedule);
                 bool canExtendUntilEnd = true;
-                // Extend the subsystem states to the end of the simulation 
+                // Extend the subsystem states to the end of the simulation
                 foreach (var subsystem in SimSystem.Subsystems)
                 {
                     if (systemSchedule.AllStates.Events.Count > 0)

--- a/src/MissionElements/Asset.cs
+++ b/src/MissionElements/Asset.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
-// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
+// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu) Scott Plantenga (splantenga@hotmail.com)
 
 using HSFUniverse;
 using System.Xml;
 using System;
-using Utilities; 
+using Utilities;
 
 namespace MissionElements
 {
@@ -14,8 +14,7 @@ namespace MissionElements
         #region Attributes
         public DynamicState AssetDynamicState{ get; private set; } //was protected, why?
         public string Name { get; private set; }
-        //TODO:make isTaskable mean something
-        public bool IsTaskable{ get; private set; }//was protected, why? do we need this?
+        public bool IsTaskable{ get; private set; }
         #endregion
 
         #region Constructors
@@ -27,7 +26,7 @@ namespace MissionElements
         {
             Name = name;
             AssetDynamicState = dynamicState;
-            IsTaskable = false;
+            IsTaskable = true; // default as True
         }
 
         public Asset(XmlNode assetXMLNode)
@@ -38,7 +37,9 @@ namespace MissionElements
                 throw new MissingMemberException("Missing name for Asset!");
             if (assetXMLNode["DynamicState"] != null)
                 AssetDynamicState = new DynamicState(assetXMLNode["DynamicState"]);
-            IsTaskable = false;
+            IsTaskable = true; // default as True
+            if (assetXMLNode["IsPassive"] != null)
+                IsTaskable = false;
         }
         #endregion
 
@@ -52,7 +53,7 @@ namespace MissionElements
         {
             if (obj == null || GetType() != obj.GetType())
                 return false;
-            return Name.Equals(((Asset)obj).Name);  
+            return Name.Equals(((Asset)obj).Name);
         }
 
         /// <summary>

--- a/src/MissionElements/Event.cs
+++ b/src/MissionElements/Event.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
 // Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
 
 using System;

--- a/src/MissionElements/Event.cs
+++ b/src/MissionElements/Event.cs
@@ -18,27 +18,27 @@ namespace MissionElements
         public Dictionary<Asset, Task> Tasks { get; private set; }
 
         /// <summary>
-        /// The time history of the State during the current Event. 
+        /// The time history of the State during the current Event.
         /// </summary>
         public SystemState State { get; private set; }
 
         /// <summary>
-        /// The start of the event associated with this State 
+        /// The start of the event associated with this State
         /// </summary>
         public Dictionary<Asset, double> EventStarts { get; private set; }
 
         /// <summary>
-        /// The start of the task associated with this State 
+        /// The start of the task associated with this State
         /// </summary>
         public Dictionary<Asset, double> TaskStarts { get; set; }
 
         /// <summary>
-        ///The end of the task associated with this State 
+        ///The end of the task associated with this State
         /// </summary>
         public Dictionary<Asset, double> TaskEnds { get; set; }
 
         /// <summary>
-        /// The end of the event associated with this State 
+        /// The end of the event associated with this State
         /// </summary>
         public Dictionary<Asset, double> EventEnds { get; set; }
 
@@ -47,7 +47,7 @@ namespace MissionElements
 
         #region Constructors
         /// <summary>
-        ///  Creates an Event, in which the Task was performed by an Asset, and the time history 
+        ///  Creates an Event, in which the Task was performed by an Asset, and the time history
         /// of the pertinent State information was saved.
         /// </summary>
         /// <param name="task"></param>
@@ -102,7 +102,7 @@ namespace MissionElements
         public double GetEventStart(Asset asset)
         {
             double time;
-                
+
             EventStarts.TryGetValue(asset, out time);
             return time;
         }
@@ -181,8 +181,8 @@ namespace MissionElements
             foreach(var assetTask in Tasks)
             {
                 eventString += assetTask.Key.Name + ":\t" + assetTask.Value.Target.ToString()+ "\t";
-                eventString += "Task Start:\t" + GetTaskStart(assetTask.Key) + "\tEvent Start:\t" + GetEventStart(assetTask.Key) + "\t"; 
-                eventString+= "Task End:\t" + GetTaskEnd(assetTask.Key) + "\tEvent End:\t" + GetEventEnd(assetTask.Key);
+                eventString += "Task Start:\t" + GetTaskStart(assetTask.Key) + "\tEvent Start:\t" + GetEventStart(assetTask.Key) + "\t";
+                eventString += "Task End:\t" + GetTaskEnd(assetTask.Key) + "\tEvent End:\t" + GetEventEnd(assetTask.Key) + "\t";
             }
 
             return eventString;

--- a/src/MissionElements/SystemState.cs
+++ b/src/MissionElements/SystemState.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) 2016 California Polytechnic State University
 // Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
 
-
-// TODO - harder diff bcuz I deleted then rewrote... need to track back history better...
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MissionElements/SystemState.cs
+++ b/src/MissionElements/SystemState.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) 2016 California Polytechnic State University
 // Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
 
+
+// TODO - harder diff bcuz I deleted then rewrote... need to track back history better...
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,7 +43,7 @@ namespace MissionElements
 
         #region Constructors
         /// <summary>
-        /// Creates an initial state   
+        /// Creates an initial state
         /// </summary>
         public SystemState()
         {
@@ -443,7 +446,7 @@ namespace MissionElements
         //        return PreviousState.GetFullProfile(key); // If no data, return profile from previous states
         //    return valueOut; //return empty profile
         //}
-        
+
         ///// <summary>
         ///// Returns the integer Profile for this state and all previous states merged into one Profile
         ///// </summary>

--- a/src/MissionElements/Task.cs
+++ b/src/MissionElements/Task.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) 2016 California Polytechnic State University
-// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu)
+﻿// Copyright (c) 2016-2023 California Polytechnic State University
+// Authors: Morgan Yost (morgan.yost125@gmail.com) Eric A. Mehiel (emehiel@calpoly.edu) Scott Plantenga (splantenga@hotmail.com)
 
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,7 @@ namespace MissionElements
         // the type of task being performed (will always be converted to a lowercase string in the constructor
          public string Type { get; private set; }
 
-        // the target associated with the task 
+        // the target associated with the task
         public Target Target { get; private set; }
 
         // The maximum number of times the task should be performed by the ENTIRE SYSTEM (all assets count towards this)
@@ -71,6 +71,13 @@ namespace MissionElements
                 else
                     tasks.Push(new Task(taskType, new Target(targetNode), maxTimesPerform));
             }
+
+            // Include Empty Task
+            DynamicStateType Type = (DynamicStateType)Enum.Parse(typeof(DynamicStateType), "NULL_STATE");
+            DynamicState emptyDS = new DynamicState(Type, new OrbitalEOMS(), new Utilities.Vector("[0]"));
+            Target emptyTgt = new Target("EmptyTarget", "EMPTY", emptyDS, 0);
+            tasks.Push(new Task("EMPTY", emptyTgt, 0));
+
             log.Info("Number of Targets Loaded: "+ tasks.Count);
 
             return allLoaded;
@@ -91,5 +98,5 @@ namespace MissionElements
     // The three types of tasks supported by Horizon
     //public enum TaskType { EMPTY, COMM, IMAGING, FLYALONG, RECOVERY }
 
-  
+
 }


### PR DESCRIPTION
key change to enable Scott Plantenga thesis work. Enable an asset to be "passive" for any given time step by including an "empty" task in the stack of possible tasks that get exhaustively considered. An asset can also be entirely passive, which is used for an "observer" asset to do supplementary calculations to enforce no collisions b/w trajectories